### PR TITLE
Disable builds for re2 package in workspace

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2478,8 +2478,8 @@ packages:
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
     hasBin: true
 
-  node-releases@2.0.48:
-    resolution: {integrity: sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==}
+  node-releases@2.0.49:
+    resolution: {integrity: sha512-f06bl1D+8ZDkn2oOQQKAh5/otFWqVnM1Q5oerA8Pex7UfT66Tx4IPHIqVVFKqFT3FUtaDstdgkM7yT7JWhqxfw==}
     engines: {node: '>=18'}
 
   nopt@10.0.1:
@@ -4391,7 +4391,7 @@ snapshots:
       baseline-browser-mapping: 2.10.38
       caniuse-lite: 1.0.30001799
       electron-to-chromium: 1.5.378
-      node-releases: 2.0.48
+      node-releases: 2.0.49
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
   buffer-crc32@1.0.0: {}
@@ -5880,7 +5880,7 @@ snapshots:
       which: 7.0.0
     optional: true
 
-  node-releases@2.0.48: {}
+  node-releases@2.0.49: {}
 
   nopt@10.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 allowBuilds:
   protobufjs: false
+  re2: false
 minimumReleaseAge: 4320


### PR DESCRIPTION
## Summary
Added re2 to the list of packages with builds disabled in the pnpm workspace configuration.

## Changes
- Added `re2: false` to the `allowBuilds` section in `pnpm-workspace.yaml`, alongside the existing `protobufjs: false` configuration

## Details
This change prevents the re2 package from being built during workspace operations, likely because a prebuilt binary is available or building from source is not necessary for this dependency.

https://claude.ai/code/session_015Ucwomod8nU2oEtG8KSzgt